### PR TITLE
fix: 🐛 improve AsyncData behaviour on failed loads

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prerelease": "npm run prepare",
     "lint": "eslint -c .eslintrc.js --ext .ts src",
     "postversion": "git push && git push --tags",
-    "prettier:cli": "prettier \"src/**/*.ts\" \"src/**/*.tsx\"",
+    "prettier:cli": "prettier \"src/**/*.ts\"",
     "prettier:check": "npm run prettier:cli -- -l",
     "prettier:fix": "npm run prettier:cli -- --write",
     "prepare": "npm run build",

--- a/src/AsyncData.ts
+++ b/src/AsyncData.ts
@@ -93,6 +93,15 @@ export class AsyncData<D, E = {}> {
   }
 
   /**
+   * Check whether data has been requested
+   *
+   * @param status
+   */
+  isAsked() {
+    return this.status !== RemoteDataStatus.NotAsked;
+  }
+
+  /**
    * Check whether any data has loaded (or that the request has failed)
    */
   isLoaded() {
@@ -131,6 +140,9 @@ export class AsyncData<D, E = {}> {
     if (this.status === RemoteDataStatus.Success) {
       return this.internal.getRight();
     }
+    if (this.status === RemoteDataStatus.Failure) {
+      throw this.internal.getLeft();
+    }
 
     throw new Error('Trying to access RemoteData before it is ready');
   }
@@ -139,14 +151,11 @@ export class AsyncData<D, E = {}> {
    *
    */
   singleValue(): D {
-    if (this.status === RemoteDataStatus.Success) {
-      if (this.internal.getRight().length !== 1) {
-        throw new Error('Data is not single-valued');
-      }
-      return this.internal.getRight()[0];
+    const val = this.value();
+    if (val.length !== 1) {
+      throw new Error('Data is not single-valued');
     }
-
-    throw new Error('Trying to access RemoteData before it is ready');
+    return val[0];
   }
 
   /**

--- a/test/AsyncData.spec.ts
+++ b/test/AsyncData.spec.ts
@@ -54,7 +54,6 @@ describe('AsyncData', () => {
       const ad = AsyncData.loading();
       expect(() => ad.value()).to.throw('Trying to access RemoteData before it is ready');
     });
-
     it('throws an error if data load failed', () => {
       const ad = AsyncData.errored(new Error('Testing error'));
       expect(() => ad.value()).to.throw('Testing error');
@@ -66,7 +65,6 @@ describe('AsyncData', () => {
       const ad = AsyncData.loaded([1]);
       expect(ad.singleValue()).to.equal(1);
     });
-
     it('throws an error if not single-valued', () => {
       const ad = AsyncData.loaded([1, 2]);
       expect(() => ad.singleValue()).to.throw('Data is not single-valued');
@@ -77,7 +75,6 @@ describe('AsyncData', () => {
         'Trying to access RemoteData before it is ready'
       );
     });
-
     it('throws an error if data load failed', () => {
       const ad = AsyncData.errored(new Error('Testing error'));
       expect(() => ad.singleValue()).to.throw('Testing error');

--- a/test/AsyncData.spec.ts
+++ b/test/AsyncData.spec.ts
@@ -8,17 +8,17 @@ describe('AsyncData', () => {
   });
   it('can map data', () => {
     const data = AsyncData.loaded([1, 2, 3, 4]);
-    expect(data.map(x => 2 * x).value()).to.deep.equal([2, 4, 6, 8]);
+    expect(data.map((x) => 2 * x).value()).to.deep.equal([2, 4, 6, 8]);
   });
   it('can filter data', () => {
     const data = AsyncData.loaded([1, 2, 3, 4]);
-    expect(data.filter(x => x % 2 === 0).value()).to.deep.equal([2, 4]);
+    expect(data.filter((x) => x % 2 === 0).value()).to.deep.equal([2, 4]);
   });
   it('can reduce data', () => {
     const data = AsyncData.loaded([1, 2, 3, 4]);
     expect(data.reduce((a, x) => a + x, 0).value()).to.deep.equal([10]);
   });
-  describe('getOptional', () => {
+  describe('.getOptional', () => {
     it('can be converted to an empty Optional when no request has been made', async () => {
       const async = AsyncData.notAsked<{}>();
       expect(async.getOptional().isPresent()).to.be.false;
@@ -42,6 +42,45 @@ describe('AsyncData', () => {
     it('can be converted to an empty Optional if there is an error', async () => {
       const async = AsyncData.errored(new Error('Oh dear'));
       expect(async.getOptional().isPresent()).to.be.false;
+    });
+  });
+
+  describe('.value', () => {
+    it('returns the internal value if successfully loaded', () => {
+      const ad = AsyncData.loaded([1]);
+      expect(ad.value()).to.deep.equal([1]);
+    });
+    it('throws an error if data is not loaded', () => {
+      const ad = AsyncData.loading();
+      expect(() => ad.value()).to.throw('Trying to access RemoteData before it is ready');
+    });
+
+    it('throws an error if data load failed', () => {
+      const ad = AsyncData.errored(new Error('Testing error'));
+      expect(() => ad.value()).to.throw('Testing error');
+    });
+  });
+
+  describe('.singleValue', () => {
+    it('returns the internal value if successfully loaded', () => {
+      const ad = AsyncData.loaded([1]);
+      expect(ad.singleValue()).to.equal(1);
+    });
+
+    it('throws an error if not single-valued', () => {
+      const ad = AsyncData.loaded([1, 2]);
+      expect(() => ad.singleValue()).to.throw('Data is not single-valued');
+    });
+    it('throws an error if data is not loaded', () => {
+      const ad = AsyncData.loading();
+      expect(() => ad.singleValue()).to.throw(
+        'Trying to access RemoteData before it is ready'
+      );
+    });
+
+    it('throws an error if data load failed', () => {
+      const ad = AsyncData.errored(new Error('Testing error'));
+      expect(() => ad.singleValue()).to.throw('Testing error');
     });
   });
 });


### PR DESCRIPTION
There was a logic mismatch in the current implementation.

Calling `isLoaded` followed by `value` would result in an error that the value was not loaded if the value was an error.

Changing this